### PR TITLE
Add copy constructor to Keys class

### DIFF
--- a/include/libcert_keys.h
+++ b/include/libcert_keys.h
@@ -36,6 +36,7 @@ namespace fty
     {
     public:
         Keys(const std::string & privateKeyPem);
+        Keys (const Keys & key);
         ~Keys();
 
         std::string getPem() const override;
@@ -47,6 +48,7 @@ namespace fty
 
     private:
         Keys(EVP_PKEY * evpPkey);   // private copy ctor
+        void importPem(const std::string & privateKeyPem);
 
         EVP_PKEY * m_evpPkey = NULL;
     

--- a/src/libcert_keys.cc
+++ b/src/libcert_keys.cc
@@ -32,18 +32,12 @@ namespace fty
 {
     Keys::Keys (const std::string &privateKeyPem)
     {
-        BIO *bio = BIO_new_mem_buf ((void *) privateKeyPem.c_str (), privateKeyPem.length ());
+        importPem(privateKeyPem);
+    }
 
-        if (bio == NULL) {
-            throw std::runtime_error ("Impossible to create the private key");
-        }
-
-        m_evpPkey = PEM_read_bio_PrivateKey (bio, NULL, NULL, NULL);
-        BIO_free (bio);
-
-        if (m_evpPkey == NULL) {
-            throw std::runtime_error ("Impossible to create the private key");
-        }
+    Keys::Keys (const Keys & key)
+    {
+        importPem(key.getPem());
     }
 
     Keys::~Keys ()
@@ -137,6 +131,22 @@ namespace fty
     Keys::Keys (EVP_PKEY *evpPkey)
     {
         m_evpPkey = evpPkey;
+
+        if (m_evpPkey == NULL) {
+            throw std::runtime_error ("Impossible to create the private key");
+        }
+    }
+
+    void Keys::importPem(const std::string & privateKeyPem)
+    {
+        BIO *bio = BIO_new_mem_buf ((void *) privateKeyPem.c_str (), privateKeyPem.length ());
+
+        if (bio == NULL) {
+            throw std::runtime_error ("Impossible to create the private key");
+        }
+
+        m_evpPkey = PEM_read_bio_PrivateKey (bio, NULL, NULL, NULL);
+        BIO_free (bio);
 
         if (m_evpPkey == NULL) {
             throw std::runtime_error ("Impossible to create the private key");


### PR DESCRIPTION
Copy ctor needed to create std::pair in [`fty-certificate-generator`](https://github.com/42ity/fty-certificate-generator)